### PR TITLE
Fixed issue with WebSocket message broadcasting

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
 
         <title>WebSocket Client</title>
 
-        <script src="client.js?v=1.0.0" defer></script>
+        <script src="client.js?v=1.0.1" defer></script>
     </head>
 
     <body>

--- a/server/server.js
+++ b/server/server.js
@@ -58,9 +58,11 @@ wss.on("close", () => {
 });
 
 function broadcast(message) {
-    clients.forEach((client) => {
+    clients.forEach((clientId, client) => {
         if (client.readyState === WebSocket.OPEN) {
             client.send(message);
+        } else {
+            console.error("WebSocket connection is not open.");
         }
     });
 }


### PR DESCRIPTION
This commit fixes the issue where WebSocket messages were not being broadcasted to all connected clients. The problem was caused by the `clientId` is the client's identifier, so if it is removed, the system won't be able to identify which client joined the room, sent a particular message, or leaved the room.